### PR TITLE
Change instance type, re-enable shiny package installation.

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -38,11 +38,11 @@
     # - name: Install tidyverse
     #   shell: "/opt/R/3.6.3/bin/R -e \"install.packages('tidyverse', repos=c('https://cran.rstudio.com/'))\""
 
-    # - name: Install shiny
-    #   shell: "/opt/R/3.6.3/bin/R -e \"install.packages('shiny', repos=c('https://cran.rstudio.com/'))\""
+    - name: Install shiny
+      shell: "/opt/R/3.6.3/bin/R -e \"install.packages('shiny', repos=c('https://cran.rstudio.com/'))\""
 
     # - name: Install BiocManager
-    #   shell: "/opt/R/3.6.3/bin/R -e \"install.packages('biocManager', repos=c('https://cran.rstudio.com/'))\""
+    #   shell: "/opt/R/3.6.3/bin/R -e \"install.packages('BiocManager', repos=c('https://cran.rstudio.com/'))\""
 
     # - name: Install RStudio Professional Drivers
     #   shell: "curl -O https://drivers.rstudio.org/7C152C12/installer/rstudio-drivers_1.6.0_amd64.deb && yes | gdebi rstudio-drivers_1.6.0_amd64.deb"
@@ -67,11 +67,11 @@
     # - name: Install tidyverse
     #   shell: "/opt/R/4.0.0/bin/R -e \"install.packages('tidyverse', repos=c('https://cran.rstudio.com/'))\""
 
-    # - name: Install shiny
-    #   shell: "/opt/R/4.0.0/bin/R -e \"install.packages('shiny', repos=c('https://cran.rstudio.com/'))\""
+    - name: Install shiny
+      shell: "/opt/R/4.0.0/bin/R -e \"install.packages('shiny', repos=c('https://cran.rstudio.com/'))\""
 
     # - name: Install BiocManager
-    #   shell: "/opt/R/4.0.0/bin/R -e \"install.packages('biocManager', repos=c('https://cran.rstudio.com/'))\""
+    #   shell: "/opt/R/4.0.0/bin/R -e \"install.packages('BiocManager', repos=c('https://cran.rstudio.com/'))\""
 
     # - name: Install RStudio Professional Drivers
     #   shell: "curl -O https://drivers.rstudio.org/7C152C12/installer/rstudio-drivers_1.6.0_amd64.deb && yes | gdebi  rstudio-drivers_1.6.0_amd64.deb"

--- a/src/template.json
+++ b/src/template.json
@@ -53,7 +53,7 @@
     "AmiGroups": "all",
     "Department": "Platform",
     "ImageName": "{{env `ImageName`}}",
-    "InstanceType": "t3.nano",
+    "InstanceType": "t3.small",
     "OwnerEmail": "it@sagebase.org",
     "Project": "Infrastructure",
     "SnapshotGroups": "all",


### PR DESCRIPTION
Was able to install on provisioned instance, changing build instance type to match that of packer-rstudio.